### PR TITLE
Don't call external stat on macOS

### DIFF
--- a/src/device_id.rs
+++ b/src/device_id.rs
@@ -53,9 +53,11 @@ impl FromStr for DeviceId {
 
 impl From<u64> for DeviceId {
     fn from(num: u64) -> Self {
+        // need to use libc, bit format is platform-dependent
+        let dev = num as libc::dev_t;
         Self {
-            major: ((num >> 8) % 65535) as u32,
-            minor: (num & 0xFF) as u32,
+            major: libc::major(dev) as u32,
+            minor: libc::minor(dev) as u32,
         }
     }
 }


### PR DESCRIPTION
This is a small change to use `std::fs::metadata()` to get the device id on macOS rather than running the external `stat` program.

This fixes an error I get on my mac when running `dysk`: "Error reading mounts: Error parsing device id". I managed to track down the cause to me having the GNU coreutils installed and on my PATH, so `stat` is GNU stat rather than the macOS stat. And GNU stat for whatever reason chokes with `-f %Hr:%Lr`, which is what was being used before.
```
$ stat -f '%Hr:%Lr' /dev/disk3s5
stat: cannot read file system information for '%Hr:%Lr': No such file or directory
  File: "/dev/disk3s5"
    ID: ebde433b00000013 Namelen: ?       Type: devfs
Block size: 512        Fundamental block size: 512
Blocks: Total: 699        Free: 0          Available: 0
Inodes: Total: 1210       Free: 0
```

The error itself is entirely my fault for using GNU coreutils on macOS, but sometimes I want to use some of the additional options and such that they provide, and I don't want to have to add a `g` prefix :)

An even simpler fix would have been to specify the full path to `stat` (`/usr/bin/stat`) in the command, rather than just `stat`. But using `std::fs::metadata()` is a much better way of doing it, and is effectively what `stat` does anyway.