### PR TITLE
feat: detect storage spaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,6 @@ core-foundation-sys = "0.8"
 io-kit-sys = "0.4"
 
 [target.'cfg(windows)'.dependencies]
-wmi = "0.18"
-listdisk-rs = { version = "0.3.4", default-features = false, features = [
-    "storagepool",
-    "volume_wmi",
-] }
 windows = { version = "0.62", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_SystemServices",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ core-foundation-sys = "0.8"
 io-kit-sys = "0.4"
 
 [target.'cfg(windows)'.dependencies]
+wmi = "0.18"
+listdisk-rs = { version = "0.3.4", default-features = false, features = [
+    "storagepool",
+    "volume_wmi",
+] }
 windows = { version = "0.62", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_SystemServices",

--- a/src/windows/volume.rs
+++ b/src/windows/volume.rs
@@ -338,7 +338,13 @@ impl Volume {
     }
 
     fn volume_kind(&self) -> VolumeKind {
-        volume_kind_detect(&self.name)
+        let kind = volume_kind_detect(&self.name);
+
+        // only pollute stderr in debug builds
+        #[cfg(debug_assertions)]
+        dbg!(&kind);
+
+        kind
     }
 
     fn volume_stats(&self) -> Result<Stats, StatsError> {

--- a/src/windows/volume/volume_utils.rs
+++ b/src/windows/volume/volume_utils.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+
+use listdisk_rs::win32::storagepool::{
+    StoragePool,
+    StoragePoolToVolume,
+};
+
+use {
+    listdisk_rs::win32::volume_wmi::Volume,
+    wmi::WMIError,
+};
+
+use {
+    windows::Win32::{
+        Foundation::{
+            CloseHandle,
+            ERROR_MORE_DATA,
+        },
+        Storage::FileSystem::{
+            CreateFileW,
+            FILE_SHARE_READ,
+            FILE_SHARE_WRITE,
+            IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS,
+            OPEN_EXISTING,
+        },
+        System::{
+            IO::DeviceIoControl,
+            Ioctl::{
+                DISK_EXTENT,
+                VOLUME_DISK_EXTENTS,
+            },
+        },
+    },
+    wmi::{
+        FilterValue,
+        WMIConnection,
+        WMIResult,
+    },
+};
+
+use crate::windows::volume::{
+    VolumeKind,
+    VolumeName,
+};
+
+pub fn volume_kind_detect(verbatim_path: &VolumeName) -> VolumeKind {
+    if let Ok(true) = is_volume_storage_space(verbatim_path) {
+        return VolumeKind::StorageSpace;
+    }
+
+    let handle = match unsafe {
+        CreateFileW(
+            verbatim_path.as_pcwstr_no_trailing_backslash(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            Default::default(),
+            None,
+        )
+    } {
+        Ok(handle) => handle,
+        Err(_) => return VolumeKind::Unknown,
+    };
+
+    let mut extents_buffer = VOLUME_DISK_EXTENTS {
+        NumberOfDiskExtents: 0,
+        Extents: [DISK_EXTENT {
+            DiskNumber: 0,
+            StartingOffset: 0,
+            ExtentLength: 0,
+        }],
+    };
+
+    let mut bytes_returned: u32 = 0;
+
+    let result = unsafe {
+        DeviceIoControl(
+            handle,
+            IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS,
+            None,
+            0,
+            Some(&mut extents_buffer as *mut _ as *mut _),
+            std::mem::size_of::<VOLUME_DISK_EXTENTS>() as u32,
+            Some(&mut bytes_returned),
+            None,
+        )
+    };
+
+    let _ = unsafe { CloseHandle(handle) };
+
+    match result {
+        Ok(_) => {
+            if extents_buffer.NumberOfDiskExtents == 1 {
+                VolumeKind::Simple {
+                    disk_number: extents_buffer.Extents[0].DiskNumber,
+                }
+            } else {
+                VolumeKind::DynamicDisk
+            }
+        }
+        Err(error) if error.code() == ERROR_MORE_DATA.to_hresult() => VolumeKind::DynamicDisk,
+        Err(_) => VolumeKind::Unknown,
+    }
+}
+
+fn is_volume_storage_space(verbatim_path: &VolumeName) -> WMIResult<bool> {
+    let wmi = WMIConnection::with_namespace_path(r#"ROOT\Microsoft\Windows\Storage"#)?;
+    let map = HashMap::from([(
+        "Path".into(),
+        FilterValue::String(verbatim_path.to_string()),
+    )]);
+
+    let volume = wmi
+        .filtered_query::<Volume>(&map)?
+        .pop()
+        .ok_or(WMIError::ResultEmpty)?;
+
+    let storage_pool = wmi.associators::<StoragePool, StoragePoolToVolume>(&volume.obj_path)?;
+    Ok(!storage_pool.is_empty())
+}


### PR DESCRIPTION
close #9 and close #10

```text
PS C:\Windows\system32>  F:\dyskinfo.exe
[C:\Users\kavin\Repos\lfs-core\src\windows\volume.rs:342:9] &kind = Simple {
    disk_number: 4,
}
[C:\Users\kavin\Repos\lfs-core\src\windows\volume.rs:342:9] &kind = StorageSpace
[C:\Users\kavin\Repos\lfs-core\src\windows\volume.rs:342:9] &kind = DynamicDisk
[C:\Users\kavin\Repos\lfs-core\src\windows\volume.rs:342:9] &kind = Unknown
[C:\Users\kavin\Repos\lfs-core\src\windows\volume.rs:342:9] &kind = Unknown
```

In a word, due to Micro$hit windows designs, we have to detect different type of volume management in totally different methods, The `Win32_*` WMI classes are too legacy, and in the`MSFT_*` Storage classes, microsoft discontinued support for Dynamic Disk.

It's not too bad though, because we have storage spaces since Windows 8, therefore no reason to use Dynamic Disk until the space is really insufficient. The extend volume does not provide speed improvement, only useful to concatenate different physical space, neither widely supported nor providing RAID-like robustness